### PR TITLE
Keep EXIF in exported data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
 				"pica-gpu": "^0.2.0",
 				"sveltejs-tippy": "^3.0.0",
 				"tinykeys": "^3.0.0",
+				"turbo_exif": "^0.1.1",
 				"unplugin-icons": "^22.1.0",
 				"yaml": "^2.7.0"
 			},
@@ -8931,6 +8932,11 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD"
+		},
+		"node_modules/turbo_exif": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/turbo_exif/-/turbo_exif-0.1.1.tgz",
+			"integrity": "sha512-CWdlXfn1D+2g5xZHsgEd6UHC2SAo51Jtj7/Hp0OFd0FytolDy5j4+9TRlhMv5XiEKyRi5vG54e+2v3AWTy0ZEg=="
 		},
 		"node_modules/turndown": {
 			"version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
 		"pica-gpu": "^0.2.0",
 		"sveltejs-tippy": "^3.0.0",
 		"tinykeys": "^3.0.0",
+		"turbo_exif": "^0.1.1",
 		"unplugin-icons": "^22.1.0",
 		"yaml": "^2.7.0"
 	},

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,8 +13,7 @@ export default defineConfig({
 		crossOriginIsolation()
 	],
 	optimizeDeps: {
-		exclude: ['onnxruntime-web']
+		exclude: ['onnxruntime-web', 'turbo_exif']
 	},
-
 	assetsInclude: ['**/*.wasm']
 });


### PR DESCRIPTION
for now:

- [ ] UserComment has incorrect encoding (idk why), 
- [ ] gps location is written but not parsed back when re-importing
- [ ] seems like timezone info of shoot date is lost somwhere along the process
- [ ] other exif data (lens, etc) that isn't inferred to metadata values are lost, we should just transfer them all from the original image
- [ ] observation-level metadata overrides are not taken into account (i doubt these would occur often for date or gps location anyways, but we should still support it just in case)

Also i'm wondering if saving things like species in the exif UserComment and/or some other fields would be useful, it would be nice so that you don't have to carry arround an extra .csv file, everything is in the images themselves (for basic metadata at least)

Closes #109