### PR TITLE
Fix dialog closing if click on background (but not backdrop)

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -44,9 +44,12 @@ jobs:
   combine-reports:
     runs-on: ubuntu-latest
     needs: test
+    # run even if tests fail
+    if: always()
     environment:
       name: '#${{ github.event.number }}: End-to-end tests report'
       url: ${{ steps.deploy-preview.outputs.preview-url }}
+    name: Combine reports
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4

--- a/src/lib/Modal.svelte
+++ b/src/lib/Modal.svelte
@@ -20,6 +20,7 @@ Show a pop-up dialog, that can be closed via a close button provided by the comp
 	import IconClose from '~icons/ph/x';
 	import ButtonIcon from './ButtonIcon.svelte';
 	import { getSettings } from './settings.svelte';
+	import { insideBoundingClientRect } from './utils';
 
 	/**
 	 * @typedef Props
@@ -66,13 +67,18 @@ Show a pop-up dialog, that can be closed via a close button provided by the comp
 </script>
 
 <dialog
+	aria-hidden={!page.state[stateKey]}
 	data-theme={theme}
 	bind:this={modalElement}
 	onclose={() => {
 		// Update state when dialog is closed via browser-controlled means (e.g. Esc key)
 		pushState('', { [stateKey]: false });
 	}}
-	onmousedown={({ target, currentTarget }) => {
+	onmousedown={({ target, currentTarget, offsetX, offsetY }) => {
+		// If we're close enough to the edge of the dialog but still "inside", don't close, because target === currentTarget but it's not the backdrop yet (see #469)
+		if (insideBoundingClientRect({ offsetX, offsetY }, currentTarget.getBoundingClientRect(), 20)) {
+			return;
+		}
 		// Close on backdrop click
 		if (target === currentTarget) close?.();
 	}}

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -660,3 +660,21 @@ export function round(value, decimals = 0) {
 	const factor = Math.pow(10, decimals);
 	return Math.round(value * factor) / factor;
 }
+
+/**
+ *
+ * @param {object} param0  offset coords from the given rect
+ * @param {number} param0.offsetX
+ * @param {number} param0.offsetY
+ * @param {DOMRect} rect
+ * @param {number} leeway how many pixels to consider still "inside" the rect even if it's outside
+ * @returns
+ */
+export function insideBoundingClientRect({ offsetX, offsetY }, rect, leeway = 0) {
+	return (
+		offsetX >= -leeway &&
+		offsetX <= rect.width + leeway &&
+		offsetY >= -leeway &&
+		offsetY <= rect.height + leeway
+	);
+}

--- a/tests/modal.spec.js
+++ b/tests/modal.spec.js
@@ -1,0 +1,16 @@
+import { issue } from './annotations';
+import { expect, test } from './fixtures';
+
+test.describe('closing a modal', () => {
+	test('when clicking outside', issue(469), async ({ page }) => {
+		await page.getByRole('navigation').getByRole('button', { name: 'Résultats' }).click();
+		// Wait for modal animation
+		await page.waitForTimeout(1000);
+		const dialog = page.getByRole('dialog').filter({ hasText: 'Exporter les résultats' });
+		await page.mouse.click(300, 570);
+		await page.waitForTimeout(1000);
+		await expect.soft(dialog).toBeVisible();
+		await page.mouse.click(50, 50);
+		await expect.soft(dialog).toBeHidden();
+	});
+});


### PR DESCRIPTION
- **💚 Upload report even if testing job fails**
- **🐛 Fix dialog closing if click on background (but not backdrop)**
