### PR TITLE
🐛 Fix inference models not being cached

### DIFF
--- a/src/lib/inference.js
+++ b/src/lib/inference.js
@@ -171,6 +171,30 @@ function inferenceModelId(protocolId, request) {
 	].join('|');
 }
 
+if (import.meta.vitest) {
+	const { test, expect } = import.meta.vitest;
+
+	test('inferenceModelId', () => {
+		const id1 = inferenceModelId('protocol1', 'http://example.com/model.onnx');
+		const id2 = inferenceModelId('protocol1', {
+			url: 'http://example.com/model.onnx',
+			method: 'GET',
+			headers: { Authorization: 'Bearer token' }
+		});
+		const id3 = inferenceModelId('protocol1', {
+			url: 'http://example.com/model.onnx',
+			method: 'GET',
+			headers: { 'X-Custom-Header': 'value', Authorization: 'Bearer token' }
+		});
+
+		expect(id1).toBe('protocol1|GET|http://example.com/model.onnx');
+		expect(id2).toBe('protocol1|GET|http://example.com/model.onnx|Authorization:Bearer token');
+		expect(id3).toBe(
+			'protocol1|GET|http://example.com/model.onnx|Authorization:Bearer token|X-Custom-Header:value'
+		);
+	});
+}
+
 /**
  * @param {import('$lib/database').HTTPRequest} model
  * @returns {string}

--- a/src/lib/inference.js
+++ b/src/lib/inference.js
@@ -159,16 +159,23 @@ export async function loadModel(
  * @returns {string}
  */
 function inferenceModelId(protocolId, request) {
-	if (typeof request === 'string') return request;
+	/** @type {Array<string|undefined>} */
+	let components = [protocolId];
 
-	return [
-		protocolId,
-		request.method,
-		request.url,
-		Object.entries(request.headers)
-			.sort(([a], [b]) => a.localeCompare(b))
-			.map(([k, v]) => `${k}:${v}`)
-	].join('|');
+	if (typeof request === 'string') {
+		components = [...components, 'GET', request];
+	} else {
+		components = [
+			...components,
+			request.method,
+			request.url,
+			...Object.entries(request.headers ?? {})
+				.sort(([a], [b]) => a.localeCompare(b))
+				.map(([k, v]) => `${k}:${v}`)
+		];
+	}
+
+	return components.filter(Boolean).join('|');
 }
 
 if (import.meta.vitest) {

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -51,7 +51,7 @@ sw.addEventListener('fetch', (/** @type {FetchEvent} */ event) => {
 	async function respond() {
 		let url = new URL(event.request.url);
 
-		if (url.searchParams.get('x-cigale-cache-as') === 'models') {
+		if (url.searchParams.get('x-cigale-cache-as') === 'model') {
 			return tryCache(event.request, MODELS_CACHE);
 		}
 
@@ -70,7 +70,7 @@ sw.addEventListener('fetch', (/** @type {FetchEvent} */ event) => {
 				throw new Error('invalid response from fetch');
 			}
 
-			if (response.status === 200) {
+			if (response.ok) {
 				const cache = await caches.open(CACHE);
 				cache.put(event.request, response.clone());
 			}
@@ -100,7 +100,7 @@ sw.addEventListener('fetch', (/** @type {FetchEvent} */ event) => {
  */
 async function tryCache(request, cacheName) {
 	const cache = await caches.open(cacheName);
-	const match = await cache.match(request.url.href);
+	const match = await cache.match(request.url);
 
 	if (match) {
 		console.debug(`Serving ${request.url} from ${cacheName} cache`);
@@ -116,7 +116,7 @@ async function tryCache(request, cacheName) {
 		throw new Error('invalid response from fetch');
 	}
 
-	if (response.status === 200) {
+	if (response.ok) {
 		const cache = await caches.open(cacheName);
 		cache.put(request, response.clone());
 	}

--- a/src/worker/procedures.js
+++ b/src/worker/procedures.js
@@ -18,19 +18,19 @@ export const PROCEDURES = /** @type {const} @satisfies {ProceduresMap} */ ({
 	},
 	loadModel: {
 		input: type({
-			protocolId: 'string',
-			request: Schemas.HTTPRequest,
-			'classmapping?': Schemas.HTTPRequest,
+			model: 'TypedArray.Uint8',
+			'classmapping?': 'string | undefined',
 			task: '"classification" | "detection"',
-			'webgpu?': 'boolean'
+			'webgpu?': 'boolean',
+			inferenceSessionId: 'string > 1'
 		}),
-		progress: type('0 <= number <= 1'),
+		progress: type('undefined'),
 		success: type('true')
 	},
-	isModelLoaded: {
+	inferenceSessionId: {
 		input: type('"classification" | "detection"'),
-		progress: type({}),
-		success: type('boolean')
+		progress: type('undefined'),
+		success: type('string | null')
 	},
 	inferBoundingBoxes: {
 		input: type({


### PR DESCRIPTION
Closes #1077

- Move fetch calls to UI thread instead of web workers, so that the service worker can hook into the fetch event (See #1077 description). 
  Call sites call `loadModel` instead of `swarpc.loadModel`. 
  The call stack is inverted, `loadModel` calls `swarpc.loadModel.broadcast` after downloading. 
  Checking if the inference session is already loaded is done before downloading, so we have to check if IDs match in the UI thread. To do that, `swarpc.isModelLoaded` was changed to `swarpc.inferenceSessionId(task)`, returning the currently loaded inference session's ID for the given task.

- Fix cache matching (we were passing a `request.url.href`... but `request.url` is a string lmao)

- Save to cache even if response is not 200 OK, use `response.ok` instead (useful in cases where the URL points to a 302 Found, for example)

