### PR TITLE
✅ Try to fix failing session isolation tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -74,6 +74,8 @@ jobs:
         shard-count: [12]
     steps:
       - uses: actions/checkout@v6
+        with: 
+          fetch-depth: 3
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: .bun-version

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -194,6 +194,7 @@ function pleyeReporter() {
 			commitAuthorEmail: authorEmail,
 			commitAuthorUsername: commitUsername,
 			branch: env.GITHUB_HEAD_REF || env.GITHUB_REF_NAME,
+			pullRequestTitle: env.PR_TITLE || '',
 			pullRequestNumber: process.env.PR_NUMBER
 				? parseInt(process.env.PR_NUMBER, 10)
 				: undefined

--- a/tests/sessions.spec.js
+++ b/tests/sessions.spec.js
@@ -16,12 +16,12 @@ test.describe('isolation', () => {
 		test.setTimeout(40_000);
 	});
 	test('no images from one session shows up in another', async ({ page, app }) => {
-		await newSession(page, { name: 'Session A' });
+		await newSession(page, { name: 'Session α' });
 		await app.tabs.go('import');
 		await importPhotos({ page }, 'lil-fella.jpeg');
 		await app.loading.wait();
 
-		await newSession(page, { name: 'Session B' });
+		await newSession(page, { name: 'Session β' });
 		await app.tabs.go('import');
 
 		await expect(page.getByText('lil-fella.jpeg')).not.toBeVisible();
@@ -32,7 +32,7 @@ test.describe('isolation', () => {
 		await expect(page.getByText('debugsquare.png')).toBeVisible();
 		await expect(page.getByText('lil-fella.jpeg')).not.toBeVisible();
 
-		await switchSession(page, 'Session A');
+		await switchSession(page, 'Session α');
 		await app.tabs.go('import');
 
 		await expect(page.getByText('lil-fella.jpeg')).toBeVisible();
@@ -40,22 +40,22 @@ test.describe('isolation', () => {
 	});
 
 	test('deleting a session only deletes its images', async ({ page, app }) => {
-		await newSession(page, { name: 'Session A' });
+		await newSession(page, { name: 'Session α' });
 		await app.tabs.go('import');
 		await importPhotos({ page }, 'lil-fella.jpeg');
 		await app.loading.wait();
 		await expect(page.getByText('lil-fella.jpeg')).toBeVisible();
 
-		await newSession(page, { name: 'Session B' });
+		await newSession(page, { name: 'Session β' });
 		await app.tabs.go('import');
 		await importPhotos({ page }, 'debugsquare.png');
 		await app.loading.wait();
 		await expect(page.getByText('debugsquare.png')).toBeVisible();
 
-		await deleteSession(page, 'Session A');
-		await expect(page.getByText('Session A')).not.toBeVisible();
+		await deleteSession(page, 'Session α');
+		await expect(page.getByText('Session α')).not.toBeVisible();
 
-		await switchSession(page, 'Session B');
+		await switchSession(page, 'Session β');
 		await app.tabs.go('import');
 		await expect(page.getByText('debugsquare.png')).toBeVisible();
 		await expect(page.getByText('lil-fella.jpeg')).not.toBeVisible();


### PR DESCRIPTION
the text "session a" appears on the page, but unrelated to a session name