### PR TITLE
⬆️ Move to docker.io image for playwright-bun

### DIFF
--- a/.github/workflows/playwright-prod.yml
+++ b/.github/workflows/playwright-prod.yml
@@ -13,7 +13,7 @@ jobs:
       name: Live tests
       url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/playwright.json
     container:
-      image: ghcr.io/gwennlbh/playwright-bun:v1.59.1
+      image: gwennlbh/playwright-bun:v1.59.1
       options: --user 1001
     permissions:
       contents: write

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -125,7 +125,7 @@ jobs:
     name: Test (shard ${{ matrix.shard-index }} of ${{ matrix.shard-count }})
     needs: predownload
     container:
-      image: ghcr.io/gwennlbh/playwright-bun:v1.59.1
+      image: gwennlbh/playwright-bun:v1.59.1
       options: --user 1001
     strategy:
       fail-fast: false

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -12,7 +12,7 @@ jobs:
   update-readme-snapshots:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/gwennlbh/playwright-bun:v1.59.1
+      image: gwennlbh/playwright-bun:v1.59.1
       options: --user 1001
 
     env:


### PR DESCRIPTION
Since we now have a minimum release age requirement, and only Dockerhub provides release dates to Renovate (see https://github.com/gwennlbh/renovate/issues/1 for more details)<!-- apk -->
[Mon May 25 11:24:56 UTC 2026] Downloading the Android app preview from Diawi:
  
<img alt="QR code" src="https://www.diawi.com/qrcode/link/DC18pZ" height=200>

https://i.diawi.com/DC18pZ
<!-- /apk -->

